### PR TITLE
🦋 Member Entity 생성 (임의) 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/thepandatingapiserver/domain/user/entity/Member.kt
+++ b/src/main/kotlin/com/thepan/thepandatingapiserver/domain/user/entity/Member.kt
@@ -1,0 +1,26 @@
+package com.thepan.thepandatingapiserver.domain.user.entity
+
+import com.thepan.thepandatingapiserver.domain.base.BaseEntity
+import com.thepan.thepandatingapiserver.domain.user.entity.enum.Sex
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+
+@Entity(name = "member")
+class Member(
+    /**
+     * ✅ unique 설정
+     * 인덱스가 형성되고, 중복을 허용하지 않는 제약조건이 추가됨
+     */
+    @Column(nullable = false, length = 30, unique = true)
+    var email: String,
+    var password: String?,
+    @Column(nullable = false, length = 20, unique = true)
+    var nickname: String,
+    @Column(nullable = false, length = 20)
+    var username: String,
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var sex: Sex
+) : BaseEntity()

--- a/src/main/kotlin/com/thepan/thepandatingapiserver/domain/user/entity/enum/Sex.kt
+++ b/src/main/kotlin/com/thepan/thepandatingapiserver/domain/user/entity/enum/Sex.kt
@@ -1,0 +1,6 @@
+package com.thepan.thepandatingapiserver.domain.user.entity.enum
+
+enum class Sex(val value: String) {
+    MALE("남자"),
+    FEMALE("여성")
+}

--- a/src/main/kotlin/com/thepan/thepandatingapiserver/domain/user/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/thepan/thepandatingapiserver/domain/user/repository/MemberRepository.kt
@@ -1,0 +1,8 @@
+package com.thepan.thepandatingapiserver.domain.user.repository
+
+import com.thepan.thepandatingapiserver.domain.user.entity.Member
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberRepository : JpaRepository<Member, Long> {
+
+}

--- a/src/main/kotlin/com/thepan/thepandatingapiserver/domain/user/service/MemberService.kt
+++ b/src/main/kotlin/com/thepan/thepandatingapiserver/domain/user/service/MemberService.kt
@@ -1,0 +1,11 @@
+package com.thepan.thepandatingapiserver.domain.user.service
+
+import com.thepan.thepandatingapiserver.domain.user.repository.MemberRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class MemberService @Autowired constructor(
+    private val memberRepository: MemberRepository
+) {
+}


### PR DESCRIPTION
## 🌸 Member Entity
- `ERD` 관계상 `Member`가 모든 `Entity`의 중심이기에 **_협업을 위해 임의_** 로 `Member Entity` 생성

  > **_Entity Column 참고 👇_**
  > -
  > - email : 사용자의 이메일, 해당 값은 `unique`함 따라서 인덱스가 형성되고, 중복을 허용하지 않는 제약조건이 추가됨
  > - password : 사용자의 비밀번호, 나중에 추가될 수 있는 **_소셜 로그인_** 을 위해 `null` 허용
  > - nickname : 사용자의 닉네임(게임으로 치면 케릭터 이름과 같음), 해당 값은 `unique`함 따라서 인덱스가 형성되고, 중복을 허용하지 않는 제약조건이 추가됨
  > - username : 사용자의 실제 이름(사용자로 부터 실명을 받아 저장할 예정)
  > - sex : 성별, `@Enumerated` 를 사용하여 `Enum Class`를 통해 `Entity`에 저장

## 🌸 MemberRepository
- 데이터를 저장하거나 조회하는 등의 행위를 위해 `Repository` 생성
- 우리 프로젝트에서 사용하고 있는 `Spring Data JPA`는 **_`JpaRepository`_** 를 사용하여 `Java`, `Kotlin` 문법으로 `database` `query`를 수행할 수 있는 기능을 제공
- 📌 `JpaRepository`를 상속받으면 `Repository`를 `JPA` 스펙에 맞게 확장하면서 기본적인 **_`CRUD`_** 함수를 사용할 수 있게 됨

- ❗️ 지금은 프로젝트 구조를 잡기위해 선어만 해두고 내부 로직은 구현 안함

## 🌸 MemberService
- `**_@Service_** Annotation` 을 사용하여 이 클래스가 `Spring` 이 관리하는 `Bean` 클래스임을 나태내고, 그 중에서도 **_비즈니스 로직_** 을 처리하는 `Class` 라는 것을 표시

- ❗️ 지금은 프로젝트 구조를 잡기위해 선어만 해두고 내부 로직은 구현 안함